### PR TITLE
data_structures__prune

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,31 +4,71 @@ A lightweight Python toolkit with reusable helpers and wrappers for everyday ETL
 
 ## Features
 
-- **Date Processing**: 
-    - Generate date arrays similar to BigQuery's `GENERATE_DATE_ARRAY`
-    - Format dates to year-month strings (`YYYY-MM` format)
-
+- **Date Processing**:
+  - Generate date arrays similar to BigQuery's `GENERATE_DATE_ARRAY`
+  - Format dates to year-month strings (`YYYY-MM` format)
+ - **Data Cleaning**:
+   - Recursive pruning for common containers (dict/list/tuple/set/frozenset) via `prune_data`
 
 ## Installation
 
-### Basic Installation
+### Basic Installation (from GitHub)
+
 ```bash
-pip install etlutil
+pip install "etlutil @ git+https://github.com/sheinnick/etlutil.git"
 ```
 
-### With Development Dependencies
+### With Development Dependencies (from GitHub)
+
 ```bash
-pip install etlutil[dev]
+pip install "etlutil[dev] @ git+https://github.com/sheinnick/etlutil.git"
 ```
 
 ### Using uv (Recommended)
+
 ```bash
-uv add etlutil
+uv add git+https://github.com/sheinnick/etlutil.git
 ```
 
 ## Quick Start
 
+### Data Cleaning (prune_data)
+
+```python
+from etlutil import prune_data
+
+data = {
+    "import_top": 1,
+    "keep": "hello test@test.test. how are you?",
+    "nested": {"secret": 1, "x": []},
+    "arr": [{"secret": 2}, {"field": "timespent"}],
+}
+
+# 1) Remove keys recursively
+clean = prune_data(data, keys_to_remove=["secret"])  # keys: list or predicate (lambda key: ...)
+
+# 2) Remove by value predicate (e.g., keep only strings with emails)
+import re
+pattern = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+keep_emails = lambda v: not (isinstance(v, str) and pattern.search(v))
+only_emails = prune_data(data, keys_to_remove=None, values_to_remove=keep_emails, remove_empty=True)
+
+# 3) Remove keys by prefix (safe for non-string keys)
+only_non_import = prune_data(data, keys_to_remove=lambda k: isinstance(k, str) and k.startswith("import_"))
+
+# 4) Depth control: counts all container levels (dict/list/tuple/set)
+limited = prune_data(data, keys_to_remove=["secret"], max_depth=1)
+```
+
+Key points:
+- `keys_to_remove`: `Iterable[Hashable] | Callable[[Hashable], bool] | None`
+- `values_to_remove`: `Iterable[Any] | Callable[[Any], bool] | None`
+- `remove_empty=True` removes: `None`, empty string, empty containers; keeps `0` and `False`
+- `max_depth=None` no limit; `0` top-level only; `>=1` counts all container levels
+- Root container type is preserved (dict/list/tuple/set/frozenset)
+
 ### Date Array Generation
+
 ```python
 from etlutil import generate_date_array
 from datetime import date
@@ -55,6 +95,7 @@ dates = generate_date_array("2024-06-01", "2024-01-01", -1, "MONTH")
 ```
 
 ### Date Formatting
+
 ```python
 from etlutil import format_year_month
 from datetime import date
@@ -72,7 +113,6 @@ format_year_month(date(2024, 1, 15))   # "2024-01" (with leading zero)
 format_year_month(date(2024, 12, 31))  # "2024-12"
 ```
 
-
 ## Supported Date Parts
 
 - `"DAY"` - Daily intervals
@@ -84,37 +124,58 @@ format_year_month(date(2024, 12, 31))  # "2024-12"
 ## Input Formats
 
 Dates can be provided as:
+
 - `date` objects: `date(2024, 1, 1)`
 - ISO format strings: `"2024-01-01"`
 
 ## Development
 
 ### Setup Development Environment
+
 ```bash
 # Clone repository
 git clone https://github.com/sheinnick/etlutil.git
 cd etlutil
 
 # Install with uv
-uv sync
-
-# Install in development mode
-uv pip install -e .
+uv sync --extra dev
 ```
 
 ### Running Tests
+
 ```bash
+# Install dev deps
+uv sync --extra dev
+
 # Run all tests
 uv run pytest
 
 # Run tests with coverage
 uv run pytest --cov=etlutil
 
-# Run specific test file
-uv run pytest tests/test_date.py
+# Run a specific file / test
+uv run pytest tests/test_data_structures.py::test_keep_only_int_keys -q
+
+# Run tests by keyword
+uv run pytest -k "email or import_prefix" -q
+
+# Re-run only last failures
+uv run pytest --last-failed -q
+
+# Verbose output and shorter tracebacks
+uv run pytest -vv --tb=short
+
+# Coverage
+uv run pytest --cov=etlutil --cov-report=term-missing
+
+# Property-based tests (optional)
+# If Hypothesis не установлен, файл пропускается автоматически.
+uv run pytest tests/test_data_structures_property.py -q
+
 ```
 
 ### Code Quality
+
 ```bash
 # Format and lint code
 uv run ruff check --fix etlutil/ tests/

--- a/etlutil/__init__.py
+++ b/etlutil/__init__.py
@@ -5,6 +5,7 @@ A lightweight Python toolkit with reusable helpers and wrappers for everyday ETL
 Built for clarity, speed, and reuse.
 """
 
+from .data_structures import prune_data
 from .date import format_year_month, generate_date_array
 
 __version__ = "0.1.0"
@@ -15,4 +16,6 @@ __all__ = [
     # Date helpers
     "generate_date_array",
     "format_year_month",
+    # Container helpers
+    "prune_data",
 ]

--- a/etlutil/data_structures.py
+++ b/etlutil/data_structures.py
@@ -1,0 +1,223 @@
+"""Data structures utilities.
+
+Provides `prune_data` to recursively clean common containers by removing selected keys
+at any nesting level and optionally dropping empty values/containers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Hashable, Iterable, Mapping, Sequence
+from collections.abc import Set as AbcSet
+from typing import Any
+
+
+def prune_data(
+    data: Any,
+    keys_to_remove: Iterable[Hashable] | Callable[[Hashable], bool] | None,
+    values_to_remove: Iterable[Any] | Callable[[Any], bool] | None = None,
+    remove_empty: bool = False,
+    *,
+    max_depth: int | None = None,
+    ) -> Any:
+    """Recursively prune keys and optionally drop empty values in containers.
+
+    Args:
+        data: Root object to process (mapping/sequence/set or primitives). Not mutated.
+        keys_to_remove: Keys to remove at any nesting level within mappings. Can be an
+            iterable of keys or a predicate `(key) -> bool`.
+        max_depth: Depth limit across containers. None means no limit; 0 means only
+            the top-level container; positive values count container levels (mapping/sequence/set)
+            below the root.
+        remove_empty: When True, remove None, empty string, and empty containers
+            (mapping/sequence/set). Values 0 and False are not treated as empty.
+        values_to_remove: Values to remove anywhere. Can be an iterable of values or
+            a predicate `(value) -> bool`.
+
+    Returns:
+        A new object with requested changes; container root preserves its type.
+
+    Raises:
+        ValueError: If max_depth is negative.
+
+    Notes:
+        - Depth counter increases when entering any container.
+        - Container types are preserved for list/tuple/set and frozenset; mappings preserve their class
+          when constructible from item pairs, otherwise fall back to dict.
+        - Set elements are kept only if hashable after processing.
+    """
+
+    # Validate depth limit early
+    if max_depth is not None and max_depth < 0:
+        raise ValueError("max_depth cannot be negative")
+
+    # Normalize key/value removal inputs into predicates
+    def make_predicate(obj: Any, error_label: str) -> tuple[Callable[[Any], bool], bool]:
+        if obj is None:
+            return (lambda _x: False, True)
+        if callable(obj):
+            return (obj, False)
+        try:
+            items = list(obj)
+        except TypeError as err:
+            raise TypeError(f"{error_label} must be Iterable or Callable") from err
+        return (lambda x: any(x == candidate for candidate in items), len(items) == 0)
+
+    key_predicate, key_predicate_is_empty = make_predicate(keys_to_remove, error_label="keys_to_remove")
+    value_predicate, value_predicate_is_empty = make_predicate(values_to_remove, error_label="values_to_remove")
+
+    # Short-circuit: if no filters/predicates are active and remove_empty is False → return input unchanged
+    if key_predicate_is_empty and value_predicate_is_empty and not remove_empty:
+        return data
+
+    def is_empty(value: Any) -> bool:
+        """Return True if value should be treated as empty for cleanup.
+
+        Rules:
+        - None is empty
+        - empty string is empty; non-empty string is not empty
+        - empty containers (mapping/sequence/set) are empty
+        - numeric zero and boolean False are not empty
+        """
+        if value is None:
+            return True
+        if isinstance(value, str):
+            return len(value) == 0
+        if isinstance(value, Mapping):
+            return len(value) == 0
+        if isinstance(value, AbcSet):
+            return len(value) == 0
+        if (
+            isinstance(value, Sequence)
+            and not isinstance(value, str)
+            and not isinstance(value, bytes)
+            and not isinstance(value, bytearray)
+        ):
+            return len(value) == 0
+        return False
+
+    def is_hashable(value: Any) -> bool:
+        """Return True if value can be safely added to a set (is hashable)."""
+        try:
+            hash(value)
+        except TypeError:
+            return False
+        return True
+
+    def process(obj: Any, container_depth: int | None) -> Any:
+        """Recursive kernel that processes containers according to rules.
+
+        Depth semantics:
+        - container_depth increases when entering any container (mapping/sequence/set)
+        - key filtering is allowed when container_depth <= max_depth
+        - recursion into children is allowed when container_depth < max_depth
+        """
+
+        # Mapping branch: filter keys if allowed; recurse into values if allowed; preserve mapping class
+        if isinstance(obj, Mapping):
+            # Determine whether we can filter keys and whether to recurse deeper
+            can_filter = max_depth is None or (container_depth is not None and container_depth <= max_depth)
+            can_recurse = max_depth is None or (container_depth is not None and container_depth < max_depth)
+
+            result_items: list[tuple[Any, Any]] = []
+            for k, v in obj.items():
+                # Apply key predicate only when filtering is allowed at this depth
+                if can_filter and key_predicate(k):
+                    continue
+                if can_recurse:
+                    # Recurse into child with incremented depth
+                    child = process(v, (0 if container_depth is None else container_depth) + 1)
+                else:
+                    # Depth limit reached; keep value as is
+                    child = v
+                if remove_empty and is_empty(child):
+                    continue
+                # Apply value predicate at mapping level only for primitives and mappings;
+                # sequences/sets apply value predicate to their own elements
+                is_seq_non_str = isinstance(child, Sequence) and not isinstance(child, str | bytes | bytearray)
+                is_set_like = isinstance(child, AbcSet)
+                if (not is_seq_non_str and not is_set_like) and value_predicate(child):
+                    continue
+                result_items.append((k, child))
+
+            # Preserve mapping class when possible; otherwise fall back to dict
+            try:
+                if isinstance(obj, dict):
+                    return dict(result_items)
+                return obj.__class__(result_items)
+            except Exception:
+                return dict(result_items)
+
+        # Sequence branch (list/tuple): optionally recurse into items; preserve list/tuple; filter empty items
+        if (
+            isinstance(obj, Sequence)
+            and not isinstance(obj, str)
+            and not isinstance(obj, bytes)
+            and not isinstance(obj, bytearray)
+        ):
+            can_recurse = max_depth is None or (container_depth is not None and container_depth < max_depth)
+            result_list: list[Any] = []
+            for item in obj:
+                if can_recurse:
+                    child = process(item, (0 if container_depth is None else container_depth) + 1)
+                else:
+                    child = item
+                if remove_empty and is_empty(child):
+                    continue
+                if value_predicate(child):
+                    continue
+                result_list.append(child)
+            if isinstance(obj, tuple):
+                return tuple(result_list)
+            return list(result_list)
+
+        # Set branch: optionally recurse into items (but not into set-like items themselves);
+        # filter empty items; keep only hashable; preserve set/frozenset
+        if isinstance(obj, AbcSet):
+            can_recurse = max_depth is None or (container_depth is not None and container_depth < max_depth)
+            result_set_items: list[Any] = []
+            for item in obj:
+                # Avoid recursing into set-like items themselves to preserve their identity
+                if can_recurse and not isinstance(item, set | frozenset):
+                    child = process(item, (0 if container_depth is None else container_depth) + 1)
+                else:
+                    child = item
+                if remove_empty and is_empty(child):
+                    continue
+                if value_predicate(child):
+                    continue
+                if is_hashable(child):
+                    result_set_items.append(child)
+            if isinstance(obj, frozenset):
+                return frozenset(result_set_items)
+            return set(result_set_items)
+
+        # Primitive or unsupported container types: return as-is
+        return obj
+
+    def empty_like(obj: Any) -> Any:
+        """Return an empty container of the same kind as obj.
+
+        Used to produce an empty root that preserves the original container type
+        when `remove_empty=True` results in an empty structure.
+        """
+        if isinstance(obj, Mapping):
+            try:
+                return obj.__class__()
+            except Exception:
+                return {}
+        if isinstance(obj, Sequence) and not isinstance(obj, str | bytes | bytearray):
+            return () if isinstance(obj, tuple) else []
+        if isinstance(obj, AbcSet):
+            return frozenset() if isinstance(obj, frozenset) else set()
+        if isinstance(obj, str):
+            return ""
+        return obj
+
+    # Kick off processing with depth=0 when there is a depth limit, else no depth tracking
+    root_processed = process(data, 0 if max_depth is not None else None)
+    # If requested, turn an empty result into an empty container of the same type as input
+    if remove_empty and is_empty(root_processed):
+        return empty_like(data)
+    return root_processed
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "hypothesis",
     "python-dateutil>=2.8.0",
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def fixtures_dir() -> Path:
+    return Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture(scope="session")
+def jira_item_session(fixtures_dir: Path) -> dict:
+    with (fixtures_dir / "jira_item.json").open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+@pytest.fixture()
+def jira_item(jira_item_session: dict) -> dict:
+    return deepcopy(jira_item_session)
+
+
+BASE_SAMPLE_DICT: dict = {
+    "import_top": 1,
+    "keep": 2,
+    3: "int_key",
+    (1, 2): "tuple_key",
+    "nested": {
+        "import_inner": 10,
+        4: "int_inner",
+    },
+    "arr": [
+        {"import_item": True, 5: "int_in_item"},
+        {"keep2": True},
+    ],
+}
+
+
+@pytest.fixture()
+def sample_dict() -> dict:
+    return deepcopy(BASE_SAMPLE_DICT)
+
+
+@pytest.fixture()
+def sample_dict_factory() -> callable:
+    def merge_nested(dst: object, src: object) -> object:
+        if isinstance(dst, dict) and isinstance(src, dict):
+            out: dict = dict(dst)
+            for k, v in src.items():
+                if k in out:
+                    out[k] = merge_nested(out[k], v)
+                else:
+                    out[k] = deepcopy(v)
+            return out
+        return deepcopy(src)
+
+    def make(**overrides: object) -> dict:
+        data = deepcopy(BASE_SAMPLE_DICT)
+        if overrides:
+            data = merge_nested(data, overrides)  # type: ignore[assignment]
+        return data
+
+    return make
+
+
+@pytest.fixture(scope="session")
+def load_json_fixture(fixtures_dir: Path):
+    def loader(name: str) -> dict:
+        with (fixtures_dir / name).open("r", encoding="utf-8") as f:
+            return json.load(f)
+    return loader
+
+

--- a/tests/fixtures/jira_item.json
+++ b/tests/fixtures/jira_item.json
@@ -1,0 +1,43 @@
+{
+    "id": "10000004",
+    "author": {
+        "accountId": "#4682B4",
+        "emailAddress": "asd@zaq.mko",
+        "displayName": "funny panda"
+    },
+    "created": "2024-11-07T16:35:51.592+0300",
+    "items": [
+        {
+            "field": "timeestimate",
+            "fieldtype": "jira",
+            "fieldId": "timeestimate",
+            "from": null,
+            "fromString": null,
+            "to": "0",
+            "toString": "3"
+        },
+        {
+            "field": "timespent",
+            "fieldtype": "jira",
+            "fieldId": "timespent",
+            "from": null,
+            "fromString": null,
+            "to": "3600",
+            "toString": "3600"
+        },
+        {
+            "field": "WorklogId",
+            "fieldtype": "jira",
+            "from": null,
+            "fromString": null,
+            "to": "111118",
+            "toString": "111118"
+        }
+    ],
+    "project_key": "ETL",
+    "issue_key": "ETL-909",
+    "issue_id": "21314",
+    "import_uuid_generated": "fb8d3ff0-d5b7-4d13-a084-1195d7317a78",
+    "import_datetime": "2024-12-23T16:30:31.668500",
+    "import_last_days": 7
+}

--- a/tests/test_data_structures.py
+++ b/tests/test_data_structures.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Hashable
+from copy import deepcopy
+
+import pytest
+
+from etlutil import prune_data
+
+
+# Basic key removal and depth
+def test_remove_keys_any_depth_basic():
+    data = {
+        "a": 1,
+        "x": {"secret": 2, "keep": 3},
+        "y": [{"secret": 4}, {"z": {"secret": 5}}],
+    }
+    result = prune_data(data, keys_to_remove=["secret"])
+    assert result == {"a": 1, "x": {"keep": 3}, "y": [{}, {"z": {}}]}
+
+
+@pytest.mark.parametrize(
+    "max_depth,expected",
+    [
+        (0, {"a": 1, "x": {"secret": 2}, "y": [{"secret": 4}, {"z": {"secret": 5}}]}),
+        (1, {"a": 1, "x": {}, "y": [{"secret": 4}, {"z": {"secret": 5}}]}),
+        (2, {"a": 1, "x": {}, "y": [{}, {"z": {"secret": 5}}]}),
+        (3, {"a": 1, "x": {}, "y": [{}, {"z": {}}]}),
+        (None, {"a": 1, "x": {}, "y": [{}, {"z": {}}]}),
+    ],
+)
+def test_depth_semantics(max_depth, expected):
+    data = {
+        "a": 1,
+        "x": {"secret": 2},
+        "y": [{"secret": 4}, {"z": {"secret": 5}}],
+    }
+    assert prune_data(data, ["secret"], max_depth=max_depth) == expected
+
+
+# Empty values cleanup
+def test_remove_empty_values_enabled():
+    data = {
+        "a": None,
+        "b": "",
+        "c": [],
+        "d": {},
+        "e": set(),
+        "f": 0,
+        "g": False,
+        "h": [None, "", [], {}, set(), 0, False, 3],
+        "i": [None, "", False, 3, [], {}, set(), 0],
+        "j": (None, "", False, 3, [], {}, set(), 0),
+    }
+    result = prune_data(data, keys_to_remove=[], remove_empty=True)
+    assert result == {"f": 0, "g": False, "h": [0, False, 3], "i": [False, 3, 0], "j": (False, 3, 0)}
+
+
+# Container types and immutability
+def test_preserve_container_types_and_sets_hashable_only():
+    data = {
+        "lst": [1, {"k": 2}],
+        "tpl": (1, {"k": 2}),
+        "st": {1, frozenset({2})},
+    }
+    result = prune_data(data, keys_to_remove=["k"], remove_empty=True)
+    assert isinstance(result["lst"], list)
+    assert isinstance(result["tpl"], tuple)
+    assert isinstance(result["st"], set)
+    assert result["lst"] == [1]
+    assert result["tpl"] == (1,)
+    assert result["st"] == {1, frozenset({2})}
+
+
+def test_input_immutability():
+    data = {"x": {"secret": 1}, "y": ["a", {"secret": 2}]}
+    original = deepcopy(data)
+    _ = prune_data(data, ["secret"], remove_empty=False)
+    assert data == original
+
+
+def test_empty_root_result_returns_empty_dict():
+    data = {"secret": None}
+    result = prune_data(data, ["secret"], remove_empty=True)
+    assert result == {}
+
+
+def test_negative_depth_raises():
+    with pytest.raises(ValueError):
+        prune_data({}, [], max_depth=-1)
+
+
+@pytest.mark.parametrize(
+    "data, expected, expected_type",
+    [
+        ([{"secret": 1}, [], 0], [0], list),
+        (({"secret": 1}, [], 0), (0,), tuple),
+    ],
+)
+def test_root_container_type_preserved_seq(data, expected, expected_type):
+    result = prune_data(data, ["secret"], remove_empty=True, max_depth=None)
+    assert isinstance(result, expected_type)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "data, expected, expected_type",
+    [
+        ({frozenset({1}), 0}, {0, frozenset({1})}, set),
+        (frozenset({0, frozenset({1})}), frozenset({0, frozenset({1})}), frozenset),
+    ],
+)
+def test_root_container_type_preserved_sets(data, expected, expected_type):
+    result = prune_data(data, ["secret"], remove_empty=True, max_depth=None)
+    assert isinstance(result, expected_type)
+    assert result == expected
+
+
+
+# Predicates and advanced filtering
+def test_values_iterable_removal_across_containers():
+    data = {
+        "lst": [0, 1, "x"],
+        "tpl": (0, 1, "x"),
+        "st": {0, 1, "x"},
+        "fs": frozenset({0, 1, "x"}),
+        "mp": {"a": 0, "b": 1, "c": "x"},
+    }
+    result = prune_data(data, keys_to_remove=[], remove_empty=False, values_to_remove=[0, "x"])
+    assert result["lst"] == [1]
+    assert result["tpl"] == (1,)
+    assert result["st"] == {1}
+    assert result["fs"] == frozenset({1})
+    assert result["mp"] == {"b": 1}
+
+
+def test_value_predicate_after_recursion_removes_empty_children():
+    data = {"a": {"secret": 1}, "b": 2}
+
+    def value_predicate(v: object) -> bool:
+        if isinstance(v, dict):
+            return len(v) == 0
+        return False
+
+    result = prune_data(data, keys_to_remove=["secret"], remove_empty=False, values_to_remove=value_predicate)
+    assert result == {"b": 2}
+
+
+def test_keys_predicate_respects_depth():
+    data = {
+        "secret": 0,
+        "keep": 0,
+        "child": {
+            "secret": 1,
+            "inner": {
+                "secret": 2,
+            },
+        },
+    }
+
+    def key_predicate(k: Hashable) -> bool:
+        return k == "secret"
+
+    result = prune_data(data, keys_to_remove=key_predicate, remove_empty=False, max_depth=1)
+    assert "secret" not in result
+    assert "secret" not in result["child"]
+    assert "secret" in result["child"]["inner"]
+
+
+def test_value_predicate_depth_for_sequence_elements():
+    depths: list[int] = []
+
+    def value_predicate(_v: object) -> bool:
+        depths.append(1)
+        return False
+
+    data = {"a": [0, 1, 2]}
+    _ = prune_data(data, keys_to_remove=[], remove_empty=False, values_to_remove=value_predicate, max_depth=1)
+    assert depths == [1, 1, 1]
+
+
+def test_key_predicate_with_non_string_keys(sample_dict: dict):
+    result = prune_data(
+        sample_dict,
+        keys_to_remove=lambda key: isinstance(key, str) and key.startswith("import_"),
+        remove_empty=False,
+    )
+
+    assert "import_top" not in result
+    assert 3 in result and result[3] == "int_key"
+    assert (1, 2) in result and result[(1, 2)] == "tuple_key"
+    assert "import_inner" not in result["nested"]
+    assert 4 in result["nested"] and result["nested"][4] == "int_inner"
+    assert "import_item" not in result["arr"][0]
+    assert 5 in result["arr"][0] and result["arr"][0][5] == "int_in_item"
+
+
+def test_keep_only_int_keys(sample_dict: dict):
+    result = prune_data(
+        sample_dict,
+        keys_to_remove=lambda key: not isinstance(key, int),
+        remove_empty=False,
+    )
+    assert result == {3: "int_key"}
+
+
+def test_keep_only_array_values(sample_dict: dict):
+    result = prune_data(
+        sample_dict,
+        keys_to_remove=None,
+        values_to_remove=lambda v: not isinstance(v, list),
+        remove_empty=False,
+    )
+    assert result == {"arr": []}
+
+
+def test_keep_only_values_with_email(sample_dict_factory):
+    data = sample_dict_factory(keep="hello test@test.test. how are you?")
+    pattern = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+
+    def value_predicate(v: object) -> bool:
+        return not (isinstance(v, str) and pattern.search(v))
+
+    result = prune_data(
+        data,
+        keys_to_remove=None,
+        values_to_remove=value_predicate,
+        remove_empty=True,
+    )
+    assert result == {"keep": "hello test@test.test. how are you?"}
+
+
+# Jira fixture tests
+def test_remove_specific_keys_from_jira_item(jira_item: dict):
+    keys_to_remove = ["import_uuid_generated", "import_datetime", "import_last_days"]
+    result = prune_data(jira_item, keys_to_remove=keys_to_remove, remove_empty=True)
+    assert "import_uuid_generated" not in result
+    assert "import_datetime" not in result
+    assert "import_last_days" not in result
+
+
+def test_values_removal_in_items_list(jira_item: dict):
+    def value_predicate(v: object) -> bool:
+        if isinstance(v, dict):
+            if v.get("toString") == "3":
+                return True
+            if v.get("field") == "timespent":
+                return True
+        return False
+
+    result = prune_data(jira_item, keys_to_remove=[], values_to_remove=value_predicate, remove_empty=True)
+    assert all(item.get("toString") != "3" and item.get("field") != "timespent" for item in result["items"])
+
+
+def test_remove_keys_with_import_prefix(jira_item: dict):
+    result = prune_data(
+        jira_item,
+        keys_to_remove=lambda key: isinstance(key, str) and key.startswith("import_"),
+        remove_empty=True,
+    )
+    assert "import_uuid_generated" not in result
+    assert "import_datetime" not in result
+    assert "import_last_days" not in result

--- a/tests/test_data_structures_edges.py
+++ b/tests/test_data_structures_edges.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Set as AbcSet
+
+import pytest
+
+from etlutil import prune_data
+
+
+def test_invalid_keys_predicate_input_raises_typeerror():
+    with pytest.raises(TypeError):
+        prune_data({}, keys_to_remove=object())
+
+
+def test_invalid_values_predicate_input_raises_typeerror():
+    with pytest.raises(TypeError):
+        prune_data({}, keys_to_remove=None, values_to_remove=object())
+
+
+class BadInitMap(Mapping):
+    def __init__(self, *, allow: bool = False, initial: dict | None = None):
+        if not allow:
+            raise TypeError("constructor requires allow=True")
+        self._data = dict(initial or {})
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self):
+        return len(self._data)
+
+
+def test_mapping_reconstruction_fallback_to_dict():
+    # Create instance successfully by passing allow=True, then prune should try BadInitMap(items) and fall back to dict
+    m = BadInitMap(allow=True, initial={"a": 1, "b": {"secret": 2}})
+    result = prune_data(m, keys_to_remove=["secret"], remove_empty=False)
+    assert isinstance(result, dict)
+    assert result == {"a": 1, "b": {}}
+
+
+def test_empty_like_fallback_mapping():
+    # After removing everything with remove_empty=True, empty_like should try BadInitMap() and fall back to {}
+    m = BadInitMap(allow=True, initial={"secret": None})
+    result = prune_data(m, keys_to_remove=["secret"], remove_empty=True)
+    assert result == {}
+
+
+class FakeSet(AbcSet):
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __contains__(self, x) -> bool:
+        return x in self._items
+
+    def __iter__(self):
+        return iter(self._items)
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+
+def test_is_hashable_exception_path_via_fake_set():
+    # Fake set can yield unhashable elements (list/dict). prune_data should skip them without raising.
+    data = {"s": FakeSet([[1, 2], {"x": 1}])}
+    result = prune_data(data, keys_to_remove=None, values_to_remove=lambda _v: False, remove_empty=False)
+    # All unhashable children are skipped; resulting set becomes empty
+    assert result["s"] == set()
+
+
+def test_empty_like_for_string_root():
+    # Root is string; with remove_empty=True and empty string input, empty_like should return ""
+    result = prune_data("", keys_to_remove=None, values_to_remove=None, remove_empty=True)
+    assert result == ""
+
+

--- a/tests/test_data_structures_property.py
+++ b/tests/test_data_structures_property.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from collections.abc import Set as AbcSet
+from copy import deepcopy
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from etlutil import prune_data
+
+# Property-based tests (skipped if hypothesis is not installed)
+hypothesis = pytest.importorskip("hypothesis")
+
+
+# Keys allowed in mappings (must be hashable)
+hashable_key = st.one_of(
+    st.text(),
+    st.integers(),
+    st.tuples(st.integers(), st.integers()),
+)
+
+# Elements allowed in sets/frozensets (must be hashable)
+hashable_elem = st.one_of(
+    st.text(),
+    st.integers(),
+    st.booleans(),
+    st.tuples(st.integers(), st.integers()),
+)
+
+
+def recursive_data_strategy() -> st.SearchStrategy:
+    """Generate nested structures: scalars, lists/tuples, dicts, sets/frozensets."""
+    base = st.one_of(st.none(), st.booleans(), st.integers(), st.text())
+
+    def expand(children: st.SearchStrategy) -> st.SearchStrategy:
+        # Build containers from already-built children
+        lists = st.lists(children, max_size=3)
+        tuples = st.lists(children, max_size=3).map(tuple)
+        mappings = st.dictionaries(keys=hashable_key, values=children, max_size=3)
+        sets = st.sets(elements=hashable_elem, max_size=3)
+        frozensets = st.sets(elements=hashable_elem, max_size=3).map(frozenset)
+        return st.one_of(lists, tuples, mappings, sets, frozensets)
+
+    return st.recursive(base, expand, max_leaves=10)
+
+
+DATA = recursive_data_strategy()
+
+
+@given(DATA)
+def test_idempotent_and_type_preserved(data):
+    """Running prune_data twice without filters should be idempotent and type-stable."""
+    r1 = prune_data(data, keys_to_remove=None, values_to_remove=None, remove_empty=False)
+    r2 = prune_data(r1, keys_to_remove=None, values_to_remove=None, remove_empty=False)
+    assert type(r1) is type(r2)
+    assert r1 == r2
+
+
+@given(DATA)
+def test_no_mutation_of_input(data):
+    """Input object must not be mutated by prune_data."""
+    before = deepcopy(data)
+    _ = prune_data(
+        data,
+        keys_to_remove=lambda k: isinstance(k, str) and k.startswith("secret_"),
+        values_to_remove=lambda v: v == "",
+        remove_empty=False,
+    )
+    assert data == before
+
+
+@given(DATA)
+def test_idempotent_with_filters(data):
+    """With fixed filters, repeated application should not change the result further."""
+
+    def key_pred(k: object) -> bool:
+        return isinstance(k, str) and k == "x"
+
+    def val_pred(v: object) -> bool:
+        return v == ""
+
+    r1 = prune_data(data, keys_to_remove=key_pred, values_to_remove=val_pred, remove_empty=True)
+    r2 = prune_data(r1, keys_to_remove=key_pred, values_to_remove=val_pred, remove_empty=True)
+    assert r1 == r2
+
+
+@given(DATA)
+def test_noop_when_no_filters_and_no_remove_empty(data):
+    """If no filters are provided and remove_empty=False, the function returns input as-is."""
+    r = prune_data(data, keys_to_remove=None, values_to_remove=None, remove_empty=False)
+    assert r is data
+
+
+def _is_empty(x: object) -> bool:
+    if x is None:
+        return True
+    if isinstance(x, str):
+        return x == ""
+    if isinstance(x, Mapping):
+        return len(x) == 0
+    if isinstance(x, AbcSet):
+        return len(x) == 0
+    if isinstance(x, Sequence) and not isinstance(x, str | bytes | bytearray):
+        return len(x) == 0
+    return False
+
+
+def _walk(x: object):
+    yield x
+    if isinstance(x, Mapping):
+        for v in x.values():
+            yield from _walk(v)
+    elif isinstance(x, Sequence) and not isinstance(x, str | bytes | bytearray):
+        for v in x:
+            yield from _walk(v)
+    elif isinstance(x, AbcSet):
+        for v in x:
+            yield from _walk(v)
+
+
+@given(DATA)
+def test_no_empty_when_remove_empty(data):
+    """With remove_empty=True, the result must not contain empty containers/values."""
+    r = prune_data(data, keys_to_remove=None, values_to_remove=None, remove_empty=True)
+    it = iter(_walk(r))
+    next(it, None)  # ignore root emptiness (allowed for primitives/fully-pruned roots)
+    assert all(not _is_empty(v) for v in it)
+
+
+@given(DATA)
+def test_monotonic_by_depth(data):
+    """Pruning deeper from an already pruned result equals pruning deeper from original."""
+
+    def key_pred(k: object) -> bool:
+        return isinstance(k, str) and k == "secret"
+
+    r1 = prune_data(data, keys_to_remove=key_pred, values_to_remove=None, remove_empty=False, max_depth=1)
+    r2a = prune_data(data, keys_to_remove=key_pred, values_to_remove=None, remove_empty=False, max_depth=2)
+    r2b = prune_data(r1, keys_to_remove=key_pred, values_to_remove=None, remove_empty=False, max_depth=2)
+    assert r2a == r2b
+
+
+@given(DATA)
+def test_sets_hashable(data):
+    """All set/frozenset elements in the result must be hashable."""
+    from collections.abc import Set as AbcSet
+
+    r = prune_data(data, keys_to_remove=None, values_to_remove=None, remove_empty=False)
+
+    def check(x: object) -> None:
+        if isinstance(x, AbcSet):
+            for e in x:
+                hash(e)
+        elif isinstance(x, dict):
+            for v in x.values():
+                check(v)
+        elif isinstance(x, list | tuple):
+            for v in x:
+                check(v)
+
+    check(r)
+
+
+@given(DATA)
+def test_deterministic(data):
+    """Same inputs and params must yield identical outputs."""
+    r1 = prune_data(data, ["k"], remove_empty=True)
+    r2 = prune_data(data, ["k"], remove_empty=True)
+    assert r1 == r2

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -57,12 +57,49 @@ class TestGenerateDateArray:
     @pytest.mark.parametrize(
         "start_date, end_date, interval, interval_type, expected",
         [
-            ("2024-01-01", "2024-01-10", 2, "DAY", [date(2024, 1, 1), date(2024, 1, 3), date(2024, 1, 5), date(2024, 1, 7), date(2024, 1, 9)]),
-            ("2024-01-01", "2024-01-22", 1, "WEEK", [date(2024, 1, 1), date(2024, 1, 8), date(2024, 1, 15), date(2024, 1, 22)]),
-            ("2024-01-01", "2024-06-01", 1, "MONTH", [date(2024, 1, 1), date(2024, 2, 1), date(2024, 3, 1), date(2024, 4, 1), date(2024, 5, 1), date(2024, 6, 1)]),
-            ("2024-01-01", "2024-12-01", 1, "QUARTER", [date(2024, 1, 1), date(2024, 4, 1), date(2024, 7, 1), date(2024, 10, 1)]),
-            ("2024-01-01", "2024-07-01", 2, "MONTH", [date(2024, 1, 1), date(2024, 3, 1), date(2024, 5, 1), date(2024, 7, 1)]),
-        ]
+            (
+                "2024-01-01",
+                "2024-01-10",
+                2,
+                "DAY",
+                [date(2024, 1, 1), date(2024, 1, 3), date(2024, 1, 5), date(2024, 1, 7), date(2024, 1, 9)],
+            ),
+            (
+                "2024-01-01",
+                "2024-01-22",
+                1,
+                "WEEK",
+                [date(2024, 1, 1), date(2024, 1, 8), date(2024, 1, 15), date(2024, 1, 22)],
+            ),
+            (
+                "2024-01-01",
+                "2024-06-01",
+                1,
+                "MONTH",
+                [
+                    date(2024, 1, 1),
+                    date(2024, 2, 1),
+                    date(2024, 3, 1),
+                    date(2024, 4, 1),
+                    date(2024, 5, 1),
+                    date(2024, 6, 1),
+                ],
+            ),
+            (
+                "2024-01-01",
+                "2024-12-01",
+                1,
+                "QUARTER",
+                [date(2024, 1, 1), date(2024, 4, 1), date(2024, 7, 1), date(2024, 10, 1)],
+            ),
+            (
+                "2024-01-01",
+                "2024-07-01",
+                2,
+                "MONTH",
+                [date(2024, 1, 1), date(2024, 3, 1), date(2024, 5, 1), date(2024, 7, 1)],
+            ),
+        ],
     )
     def test_interval_types(self, start_date, end_date, interval, interval_type, expected):
         """Test different interval types with parametrization."""
@@ -80,7 +117,7 @@ class TestGenerateDateArray:
         [
             ("2024-01-05", "2024-01-01", []),  # Empty range
             ("2024-01-01", "2024-01-01", [date(2024, 1, 1)]),  # Single date
-        ]
+        ],
     )
     def test_edge_cases(self, start_date, end_date, expected):
         """Test edge cases with parametrization."""
@@ -112,12 +149,28 @@ class TestGenerateDateArray:
     @pytest.mark.parametrize(
         "start_date, end_date, interval, interval_type, expected",
         [
-            ("2024-01-01", "2024-12-31", 30, "DAY", [
-                date(2024, 1, 1), date(2024, 1, 31), date(2024, 3, 1), date(2024, 3, 31),
-                date(2024, 4, 30), date(2024, 5, 30), date(2024, 6, 29), date(2024, 7, 29),
-                date(2024, 8, 28), date(2024, 9, 27), date(2024, 10, 27), date(2024, 11, 26), date(2024, 12, 26)
-            ]),
-        ]
+            (
+                "2024-01-01",
+                "2024-12-31",
+                30,
+                "DAY",
+                [
+                    date(2024, 1, 1),
+                    date(2024, 1, 31),
+                    date(2024, 3, 1),
+                    date(2024, 3, 31),
+                    date(2024, 4, 30),
+                    date(2024, 5, 30),
+                    date(2024, 6, 29),
+                    date(2024, 7, 29),
+                    date(2024, 8, 28),
+                    date(2024, 9, 27),
+                    date(2024, 10, 27),
+                    date(2024, 11, 26),
+                    date(2024, 12, 26),
+                ],
+            ),
+        ],
     )
     def test_large_interval(self, start_date, end_date, interval, interval_type, expected):
         """Test with large interval values."""
@@ -128,14 +181,70 @@ class TestGenerateDateArray:
     @pytest.mark.parametrize(
         "start_date, end_date, interval, interval_type, expected",
         [
-            ("2024-01-05", "2024-01-01", -1, "DAY", [date(2024, 1, 5), date(2024, 1, 4), date(2024, 1, 3), date(2024, 1, 2), date(2024, 1, 1)]),
-            ("2024-01-22", "2024-01-01", -1, "WEEK", [date(2024, 1, 22), date(2024, 1, 15), date(2024, 1, 8), date(2024, 1, 1)]),
-            ("2024-06-01", "2024-01-01", -1, "MONTH", [date(2024, 6, 1), date(2024, 5, 1), date(2024, 4, 1), date(2024, 3, 1), date(2024, 2, 1), date(2024, 1, 1)]),
-            ("2024-12-01", "2024-01-01", -1, "QUARTER", [date(2024, 12, 1), date(2024, 9, 1), date(2024, 6, 1), date(2024, 3, 1)]),
-            ("2028-01-01", "2024-01-01", -1, "YEAR", [date(2028, 1, 1), date(2027, 1, 1), date(2026, 1, 1), date(2025, 1, 1), date(2024, 1, 1)]),
-            ("2024-01-10", "2024-01-01", -2, "DAY", [date(2024, 1, 10), date(2024, 1, 8), date(2024, 1, 6), date(2024, 1, 4), date(2024, 1, 2)]),
-            ("2024-12-01", "2024-01-01", -2, "MONTH", [date(2024, 12, 1), date(2024, 10, 1), date(2024, 8, 1), date(2024, 6, 1), date(2024, 4, 1), date(2024, 2, 1)]),
-        ]
+            (
+                "2024-01-05",
+                "2024-01-01",
+                -1,
+                "DAY",
+                [date(2024, 1, 5), date(2024, 1, 4), date(2024, 1, 3), date(2024, 1, 2), date(2024, 1, 1)],
+            ),
+            (
+                "2024-01-22",
+                "2024-01-01",
+                -1,
+                "WEEK",
+                [date(2024, 1, 22), date(2024, 1, 15), date(2024, 1, 8), date(2024, 1, 1)],
+            ),
+            (
+                "2024-06-01",
+                "2024-01-01",
+                -1,
+                "MONTH",
+                [
+                    date(2024, 6, 1),
+                    date(2024, 5, 1),
+                    date(2024, 4, 1),
+                    date(2024, 3, 1),
+                    date(2024, 2, 1),
+                    date(2024, 1, 1),
+                ],
+            ),
+            (
+                "2024-12-01",
+                "2024-01-01",
+                -1,
+                "QUARTER",
+                [date(2024, 12, 1), date(2024, 9, 1), date(2024, 6, 1), date(2024, 3, 1)],
+            ),
+            (
+                "2028-01-01",
+                "2024-01-01",
+                -1,
+                "YEAR",
+                [date(2028, 1, 1), date(2027, 1, 1), date(2026, 1, 1), date(2025, 1, 1), date(2024, 1, 1)],
+            ),
+            (
+                "2024-01-10",
+                "2024-01-01",
+                -2,
+                "DAY",
+                [date(2024, 1, 10), date(2024, 1, 8), date(2024, 1, 6), date(2024, 1, 4), date(2024, 1, 2)],
+            ),
+            (
+                "2024-12-01",
+                "2024-01-01",
+                -2,
+                "MONTH",
+                [
+                    date(2024, 12, 1),
+                    date(2024, 10, 1),
+                    date(2024, 8, 1),
+                    date(2024, 6, 1),
+                    date(2024, 4, 1),
+                    date(2024, 2, 1),
+                ],
+            ),
+        ],
     )
     def test_negative_intervals(self, start_date, end_date, interval, interval_type, expected):
         """Test negative intervals with parametrization."""
@@ -147,7 +256,7 @@ class TestGenerateDateArray:
         [
             ("2024-01-01", "2024-01-01", -1, "DAY", [date(2024, 1, 1)]),  # Same start and end date
             ("2024-01-01", "2024-01-05", -1, "DAY", []),  # Start date before end date with negative interval
-        ]
+        ],
     )
     def test_negative_interval_edge_cases(self, start_date, end_date, interval, interval_type, expected):
         """Test negative interval edge cases."""
@@ -178,7 +287,7 @@ class TestGenerateDateArray:
             (2023, 365),  # Regular year
             (2024, 366),  # Leap year
             (2025, 365),  # Regular year
-        ]
+        ],
     )
     def test_year_lengths(self, year, expected_days):
         """Test that different years have correct number of days."""
@@ -248,7 +357,7 @@ class TestFormatYearMonth:
         [
             (date(2023, 6, 10), "2023-06"),
             (date(2025, 11, 25), "2025-11"),
-        ]
+        ],
     )
     def test_different_years(self, input_date, expected):
         """Test with different years using parametrization."""
@@ -262,7 +371,7 @@ class TestFormatYearMonth:
             (date(2024, 5, 1), "2024-05"),  # First day of month
             (date(2024, 2, 29), "2024-02"),  # Last day of month (leap year)
             (date(2024, 8, 15), "2024-08"),  # Middle of month
-        ]
+        ],
     )
     def test_edge_cases_days(self, input_date, expected):
         """Test edge cases with different days of month."""
@@ -286,7 +395,7 @@ class TestFormatYearMonth:
             ("2024-05-01", "2024-05"),  # First day of month
             ("2024-12-31", "2024-12"),  # Last day of month
             ("2024-02-29", "2024-02"),  # Leap year February
-        ]
+        ],
     )
     def test_string_edge_cases(self, date_string, expected):
         """Test string input edge cases."""
@@ -300,7 +409,7 @@ class TestFormatYearMonth:
             "invalid-date",
             "2024-13-01",  # Invalid month
             "2024-02-30",  # Invalid day for February
-        ]
+        ],
     )
     def test_invalid_date_string(self, invalid_date):
         """Test that invalid date string raises ValueError."""


### PR DESCRIPTION
# Data Cleaning
## prune_data
Recursive pruning for common containers (dict/list/tuple/set/frozenset) via `prune_data`

```python
from etlutil import prune_data

data = {
    "import_top": 1,
    "keep": "hello test@test.test. how are you?",
    "nested": {"secret": 1, "x": []},
    "arr": [{"secret": 2}, {"field": "timespent"}],
}

# 1) Remove keys recursively
clean = prune_data(data, keys_to_remove=["secret"])  # keys: list or predicate (lambda key: ...)

# 2) Remove by value predicate (e.g., keep only strings with emails)
import re
pattern = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
keep_emails = lambda v: not (isinstance(v, str) and pattern.search(v))
only_emails = prune_data(data, keys_to_remove=None, values_to_remove=keep_emails, remove_empty=True)

# 3) Remove keys by prefix (safe for non-string keys)
only_non_import = prune_data(data, keys_to_remove=lambda k: isinstance(k, str) and k.startswith("import_"))

# 4) Depth control: counts all container levels (dict/list/tuple/set)
limited = prune_data(data, keys_to_remove=["secret"], max_depth=1)
```

Key points:
- `keys_to_remove`: `Iterable[Hashable] | Callable[[Hashable], bool] | None`
- `values_to_remove`: `Iterable[Any] | Callable[[Any], bool] | None`
- `remove_empty=True` removes: `None`, empty string, empty containers; keeps `0` and `False`
- `max_depth=None` no limit; `0` top-level only; `>=1` counts all container levels
- Root container type is preserved (dict/list/tuple/set/frozenset)

## tests coverage
```
============================== tests coverage =========
___coverage: platform darwin, python 3.13.5-final-0 ___

Name                         Stmts   Miss  Cover
------------------------------------------------
etlutil/__init__.py              6      0   100%
etlutil/data_structures.py     112      0   100%
etlutil/date.py                 44      0   100%
------------------------------------------------
TOTAL                          162      0   100%
============================ 90 passed in 1.62s ========
```