### PR TITLE
data_structures: move_unknown_keys_to_extra: add always_add_extra parameter

### DIFF
--- a/etlutil/data_structures.py
+++ b/etlutil/data_structures.py
@@ -645,6 +645,7 @@ def move_unknown_keys_to_extra(
     allowed_keys: Iterable[Hashable],
     *,
     extra_key: str = "extra_collected",
+    always_add_extra: bool = False,
 ) -> tuple[dict, list[str]]:
     """Move unknown keys from dict to extra collection, keeping only whitelisted keys.
 
@@ -652,6 +653,8 @@ def move_unknown_keys_to_extra(
         data: Input dictionary to normalize. Must be a dict.
         allowed_keys: Iterable of allowed keys (whitelist). All keys converted to str.
         extra_key: Key name for collecting extra items. Defaults to "extra_collected".
+        always_add_extra: If True, always add extra_key even when no keys were moved.
+            Defaults to False (only add extra_key when there are moved keys).
 
     Returns:
         Tuple of (normalized_dict, moved_keys_list).
@@ -680,6 +683,14 @@ def move_unknown_keys_to_extra(
         {'extra_collected': {'age': 30, 'city': 'berlin'}, 'id': 123, 'name': 'alex'}
         >>> moved
         ['age', 'city']
+
+        >>> # Always add extra_collected even when no keys moved
+        >>> data = {"id": 123, "name": "alex"}
+        >>> result, moved = move_unknown_keys_to_extra(data, ["id", "name"], always_add_extra=True)
+        >>> result
+        {'extra_collected': {}, 'id': 123, 'name': 'alex'}
+        >>> moved
+        []
 
         >>> # Key collision example
         >>> data = {"1": "str_val", 1: "int_val"}
@@ -743,8 +754,8 @@ def move_unknown_keys_to_extra(
             moved_keys.append(final_key)
 
     # Step 4: Add extra items under extra_key if needed
-    # Only create extra collection if there are items to collect and extra_key is not None
-    if extra_items and extra_key is not None:
+    # Create extra collection if there are items OR if always_add_extra is True
+    if (extra_items or always_add_extra) and extra_key is not None:
         kept_items[extra_key] = extra_items
 
     # Step 5: Sort all keys lexicographically for consistent output

--- a/tests/test_data_structures.py
+++ b/tests/test_data_structures.py
@@ -623,6 +623,31 @@ def test_move_unknown_keys_all_allowed():
     assert "extra_collected" not in result
 
 
+def test_move_unknown_keys_all_allowed_with_always_add_extra():
+    """When all keys are allowed but always_add_extra=True, extra_collected should be empty dict."""
+    data = {"id": 123, "name": "alex"}
+    result, moved = move_unknown_keys_to_extra(data, ["id", "name"], always_add_extra=True)
+
+    assert result == {"extra_collected": {}, "id": 123, "name": "alex"}
+    assert moved == []
+    assert "extra_collected" in result
+    assert result["extra_collected"] == {}
+
+
+def test_move_unknown_keys_with_moves_and_always_add_extra():
+    """When always_add_extra=True and there are moved keys, extra_collected should contain them."""
+    data = {"id": 123, "name": "alex", "age": 30, "city": "berlin"}
+    result, moved = move_unknown_keys_to_extra(data, ["id", "name"], always_add_extra=True)
+
+    expected = {
+        "extra_collected": {"age": 30, "city": "berlin"},
+        "id": 123,
+        "name": "alex",
+    }
+    assert result == expected
+    assert set(moved) == {"age", "city"}
+
+
 def test_move_unknown_keys_none_allowed():
     """When no keys are in whitelist, all should go to extra_collected."""
     data = {"id": 123, "name": "alex"}


### PR DESCRIPTION
data_structures.move_unknown_keys_to_extra
       add always_add_extra parameter

- Introduced always_add_extra to ensure extra_key is added even when no keys are moved.
- Updated function documentation and examples to reflect the new behavior.
- Enhanced tests to cover scenarios with always_add_extra, ensuring correct handling of extra_collected.