### PR TITLE
date: get_relative_date_frame()

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A lightweight Python toolkit with reusable helpers and wrappers for everyday ETL
 - **Date Processing**:
   - Generate date arrays similar to BigQuery's `GENERATE_DATE_ARRAY`
   - Format dates to year-month strings (`YYYY-MM` format)
+  - Get relative date ranges (current/previous/next periods)
 - **Data Cleaning**:
   - Recursive pruning for common containers (dict/list/tuple/set/frozenset) via `prune_data`
   - Dictionary normalization with whitelist filtering via `move_unknown_keys_to_extra`
@@ -225,6 +226,55 @@ year_month = format_year_month("2024-03-16")
 # Handles different months correctly
 format_year_month(date(2024, 1, 15))   # "2024-01" (with leading zero)
 format_year_month(date(2024, 12, 31))  # "2024-12"
+```
+
+### Relative Date Ranges
+
+```python
+from etlutil import get_relative_date_frame
+
+# Current periods (n=0)
+current_month = get_relative_date_frame("MONTH", 0)
+# Result: ("2024-06-01", "2024-06-30") - current month boundaries
+
+current_quarter = get_relative_date_frame("QUARTER", 0)
+# Result: ("2024-04-01", "2024-06-30") - Q2 2024 if current date is in Q2
+
+current_year = get_relative_date_frame("YEAR", 0)
+# Result: ("2024-01-01", "2024-12-31") - current year
+
+# Previous periods (n=-1)
+last_month = get_relative_date_frame("MONTH", -1)
+# Result: ("2024-05-01", "2024-05-31") - previous month
+
+last_quarter = get_relative_date_frame("QUARTER", -1)
+# Result: ("2024-01-01", "2024-03-31") - Q1 2024 if current is Q2
+
+# Next periods (n=1)
+next_week = get_relative_date_frame("WEEK", 1)
+# Result: ("2024-06-17", "2024-06-23") - next week (Monday to Sunday)
+
+next_year = get_relative_date_frame("YEAR", 1)
+# Result: ("2025-01-01", "2025-12-31") - next year
+
+# Multiple periods
+six_months_ago = get_relative_date_frame("MONTH", -6)
+# Result: ("2023-12-01", "2023-12-31") - 6 months ago
+
+# Default parameters (MONTH, n=0)
+this_month = get_relative_date_frame()
+# Result: same as get_relative_date_frame("MONTH", 0)
+
+# Use cases for ETL/Analytics
+def get_data_for_period(period_type="MONTH", offset=-1):
+    """Get data for relative time period."""
+    start_date, end_date = get_relative_date_frame(period_type, offset)
+    return f"SELECT * FROM events WHERE date BETWEEN '{start_date}' AND '{end_date}'"
+
+# Examples:
+get_data_for_period("MONTH", -1)    # Last month's data
+get_data_for_period("QUARTER", 0)   # Current quarter's data
+get_data_for_period("WEEK", -4)     # 4 weeks ago data
 ```
 
 ## Supported Date Parts

--- a/README.md
+++ b/README.md
@@ -265,16 +265,29 @@ six_months_ago = get_relative_date_frame("MONTH", -6)
 this_month = get_relative_date_frame()
 # Result: same as get_relative_date_frame("MONTH", 0)
 
+# Custom base date (instead of today)
+custom_month = get_relative_date_frame("MONTH", 0, date_from="2024-06-15")
+# Result: ("2024-06-01", "2024-06-30") - June 2024 regardless of current date
+
+custom_quarter = get_relative_date_frame("QUARTER", -1, date_from=date(2024, 6, 15))
+# Result: ("2024-01-01", "2024-03-31") - Q1 2024 (previous quarter from June)
+
 # Use cases for ETL/Analytics
-def get_data_for_period(period_type="MONTH", offset=-1):
+def get_data_for_period(period_type="MONTH", offset=-1, date_base=None):
     """Get data for relative time period."""
-    start_date, end_date = get_relative_date_frame(period_type, offset)
+    start_date, end_date = get_relative_date_frame(period_type, offset, date_from=date_base)
     return f"SELECT * FROM events WHERE date BETWEEN '{start_date}' AND '{end_date}'"
 
 # Examples:
-get_data_for_period("MONTH", -1)    # Last month's data
+get_data_for_period("MONTH", -1)    # Last month's data (from today)
 get_data_for_period("QUARTER", 0)   # Current quarter's data
 get_data_for_period("WEEK", -4)     # 4 weeks ago data
+
+# With custom base date for consistent reporting
+report_date = "2024-06-30"  # End of Q2 2024
+get_data_for_period("QUARTER", 0, report_date)   # Q2 2024 data
+get_data_for_period("QUARTER", -1, report_date)  # Q1 2024 data
+get_data_for_period("YEAR", 0, report_date)      # 2024 full year data
 ```
 
 ## Supported Date Parts

--- a/etlutil/__init__.py
+++ b/etlutil/__init__.py
@@ -6,7 +6,7 @@ Built for clarity, speed, and reuse.
 """
 
 from .data_structures import convert_dict_types, move_unknown_keys_to_extra, prune_data, walk
-from .date import format_year_month, generate_date_array
+from .date import format_year_month, generate_date_array, get_relative_date_frame
 
 __version__ = "0.1.0"
 __author__ = "Nikita Shein"
@@ -16,6 +16,7 @@ __all__ = [
     # Date helpers
     "generate_date_array",
     "format_year_month",
+    "get_relative_date_frame",
     # Container helpers
     "convert_dict_types",
     "move_unknown_keys_to_extra",

--- a/etlutil/date.py
+++ b/etlutil/date.py
@@ -5,6 +5,7 @@ Date processing helper functions for ETL tasks.
 from datetime import date, timedelta
 from typing import Literal
 
+import pendulum
 from dateutil.relativedelta import relativedelta
 
 DatePart = Literal["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]
@@ -128,3 +129,60 @@ def generate_date_array(
         step += 1
 
     return date_list
+
+
+def get_relative_date_frame(date_part: DatePart = "MONTH", n: int = 0):
+    """
+    Args:
+        date_part: Date part - DAY, WEEK, MONTH, QUARTER, or YEAR (default MONTH)
+        n: relative offset (0 = current, <0 = past, >0 = future)
+
+    Returns:
+        tuple[str, str]: (start_date, end_date) in YYYY-MM-DD format
+
+    Raises:
+        ValueError: If date_part is not one of the supported values
+    Examples:
+        >>> get_relative_date_frame("MONTH", 0)  # current month
+        ('2024-01-01', '2024-01-31')
+
+        >>> get_relative_date_frame("MONTH", -1)  # previous month
+        ('2023-12-01', '2023-12-31')
+
+        >>> get_relative_date_frame("QUARTER", 1)  # next quarter
+        ('2024-04-01', '2024-06-30')
+
+        >>> get_relative_date_frame("YEAR", -2)  # 2 years ago
+        ('2022-01-01', '2022-12-31')
+
+    """
+    today = pendulum.today()
+
+    match date_part:
+        case "DAY":
+            target = today.add(days=n)
+            start, end = target.start_of("day"), target.end_of("day")
+
+        case "WEEK":
+            target = today.add(weeks=n)
+            start, end = target.start_of("week"), target.end_of("week")
+
+        case "MONTH":
+            target = today.add(months=n)
+            start, end = target.start_of("month"), target.end_of("month")
+
+        case "QUARTER":
+            target = today.add(months=3 * n)
+            # Calculate quarter manually since pendulum doesn't support "quarter"
+            quarter_month = ((target.month - 1) // 3) * 3 + 1  # 1, 4, 7, or 10
+            start = target.replace(month=quarter_month, day=1).start_of("month")
+            end = target.replace(month=quarter_month + 2, day=1).end_of("month")
+
+        case "YEAR":
+            target = today.add(years=n)
+            start, end = target.start_of("year"), target.end_of("year")
+
+        case _:
+            raise ValueError("date_part must be - DAY, WEEK, MONTH, QUARTER, or YEAR")
+
+    return start.to_date_string(), end.to_date_string()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
+    "pendulum>=3.1.0",
     "python-dateutil>=2.8.0",
 ]
 

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -2,7 +2,7 @@ from datetime import date
 
 import pytest
 
-from etlutil.date import format_year_month, generate_date_array
+from etlutil.date import format_year_month, generate_date_array, get_relative_date_frame
 
 
 # ==================== FIXTURES ====================
@@ -415,3 +415,245 @@ class TestFormatYearMonth:
         """Test that invalid date string raises ValueError."""
         with pytest.raises(ValueError):
             format_year_month(invalid_date)
+
+
+# ==================== GET_RELATIVE_DATE_FRAME TESTS ====================
+class TestGetRelativeDateFrame:
+    """Test cases for get_relative_date_frame function using fixtures and parametrization."""
+
+    # ==================== FIXTURES ====================
+    @pytest.fixture
+    def mock_today(self, monkeypatch):
+        """Mock pendulum.today() to return a fixed date for consistent testing."""
+        import pendulum
+
+        # Mock today to be 2024-06-15 (middle of year, middle of month, Saturday)
+        fixed_today = pendulum.parse("2024-06-15T12:00:00")
+
+        def mock_today_func():
+            return fixed_today
+
+        monkeypatch.setattr(pendulum, "today", mock_today_func)
+        return fixed_today
+
+    @pytest.fixture
+    def expected_current_periods(self):
+        """Expected results for current periods (n=0)."""
+        return {
+            "DAY": ("2024-06-15", "2024-06-15"),
+            "WEEK": ("2024-06-10", "2024-06-16"),  # Monday to Sunday
+            "MONTH": ("2024-06-01", "2024-06-30"),
+            "QUARTER": ("2024-04-01", "2024-06-30"),  # Q2
+            "YEAR": ("2024-01-01", "2024-12-31"),
+        }
+
+    # ==================== BASIC FUNCTIONALITY ====================
+    def test_current_periods(self, mock_today, expected_current_periods):
+        """Test current periods (n=0) for all date parts."""
+        for date_part, expected in expected_current_periods.items():
+            result = get_relative_date_frame(date_part, 0)
+            assert result == expected, f"Failed for {date_part}"
+
+    @pytest.mark.parametrize(
+        "date_part, n, expected",
+        [
+            # Previous periods (n=-1)
+            ("DAY", -1, ("2024-06-14", "2024-06-14")),
+            ("WEEK", -1, ("2024-06-03", "2024-06-09")),
+            ("MONTH", -1, ("2024-05-01", "2024-05-31")),
+            ("QUARTER", -1, ("2024-01-01", "2024-03-31")),  # Q1
+            ("YEAR", -1, ("2023-01-01", "2023-12-31")),
+            # Next periods (n=1)
+            ("DAY", 1, ("2024-06-16", "2024-06-16")),
+            ("WEEK", 1, ("2024-06-17", "2024-06-23")),
+            ("MONTH", 1, ("2024-07-01", "2024-07-31")),
+            ("QUARTER", 1, ("2024-07-01", "2024-09-30")),  # Q3
+            ("YEAR", 1, ("2025-01-01", "2025-12-31")),
+        ],
+    )
+    def test_relative_periods(self, mock_today, date_part, n, expected):
+        """Test relative periods with parametrization."""
+        result = get_relative_date_frame(date_part, n)
+        assert result == expected
+
+    # ==================== MULTIPLE PERIODS ====================
+    @pytest.mark.parametrize(
+        "date_part, n, expected",
+        [
+            # Multiple previous periods
+            ("DAY", -7, ("2024-06-08", "2024-06-08")),
+            ("WEEK", -4, ("2024-05-13", "2024-05-19")),
+            ("MONTH", -6, ("2023-12-01", "2023-12-31")),
+            ("QUARTER", -2, ("2023-10-01", "2023-12-31")),  # Q4 2023
+            ("YEAR", -3, ("2021-01-01", "2021-12-31")),
+            # Multiple next periods
+            ("DAY", 10, ("2024-06-25", "2024-06-25")),
+            ("WEEK", 8, ("2024-08-05", "2024-08-11")),
+            ("MONTH", 12, ("2025-06-01", "2025-06-30")),
+            ("QUARTER", 3, ("2025-01-01", "2025-03-31")),  # Q1 2025
+            ("YEAR", 5, ("2029-01-01", "2029-12-31")),
+        ],
+    )
+    def test_multiple_periods(self, mock_today, date_part, n, expected):
+        """Test multiple periods forward and backward."""
+        result = get_relative_date_frame(date_part, n)
+        assert result == expected
+
+    # ==================== QUARTER SPECIFIC TESTS ====================
+    @pytest.mark.parametrize(
+        "n, expected_quarter, expected_range",
+        [
+            (-1, "Q1", ("2024-01-01", "2024-03-31")),
+            (0, "Q2", ("2024-04-01", "2024-06-30")),
+            (1, "Q3", ("2024-07-01", "2024-09-30")),
+            (2, "Q4", ("2024-10-01", "2024-12-31")),
+            (4, "Q2_2025", ("2025-04-01", "2025-06-30")),  # Same quarter next year
+            (-4, "Q2_2023", ("2023-04-01", "2023-06-30")),  # Same quarter previous year
+        ],
+    )
+    def test_quarter_boundaries(self, mock_today, n, expected_quarter, expected_range):
+        """Test quarter boundaries and transitions."""
+        result = get_relative_date_frame("QUARTER", n)
+        assert result == expected_range, f"Failed for {expected_quarter}"
+
+    # ==================== YEAR BOUNDARY TESTS ====================
+    @pytest.mark.parametrize(
+        "date_part, n, expected",
+        [
+            # Cross year boundaries
+            ("MONTH", 6, ("2024-12-01", "2024-12-31")),  # December 2024
+            ("MONTH", 7, ("2025-01-01", "2025-01-31")),  # January 2025
+            ("MONTH", -6, ("2023-12-01", "2023-12-31")),  # December 2023
+            ("MONTH", -7, ("2023-11-01", "2023-11-30")),  # November 2023
+        ],
+    )
+    def test_year_boundaries(self, mock_today, date_part, n, expected):
+        """Test crossing year boundaries."""
+        result = get_relative_date_frame(date_part, n)
+        assert result == expected
+
+    # ==================== LEAP YEAR HANDLING ====================
+    def test_leap_year_february(self, monkeypatch):
+        """Test February in leap year (2024)."""
+        import pendulum
+
+        # Mock today to be in February 2024 (leap year)
+        fixed_today = pendulum.parse("2024-02-15T12:00:00")
+        monkeypatch.setattr(pendulum, "today", lambda: fixed_today)
+
+        result = get_relative_date_frame("MONTH", 0)
+        assert result == ("2024-02-01", "2024-02-29")  # 29 days in leap year
+
+    def test_non_leap_year_february(self, monkeypatch):
+        """Test February in non-leap year (2023)."""
+        import pendulum
+
+        # Mock today to be in February 2023 (non-leap year)
+        fixed_today = pendulum.parse("2023-02-15T12:00:00")
+        monkeypatch.setattr(pendulum, "today", lambda: fixed_today)
+
+        result = get_relative_date_frame("MONTH", 0)
+        assert result == ("2023-02-01", "2023-02-28")  # 28 days in non-leap year
+
+    # ==================== WEEK START TESTS ====================
+    def test_week_starts_monday(self, mock_today):
+        """Test that weeks start on Monday (ISO 8601 standard)."""
+        # Our mock date is Saturday 2024-06-15
+        result = get_relative_date_frame("WEEK", 0)
+        start_date, end_date = result
+
+        # Week should start on Monday 2024-06-10 and end on Sunday 2024-06-16
+        assert start_date == "2024-06-10"  # Monday
+        assert end_date == "2024-06-16"  # Sunday
+
+    @pytest.mark.parametrize(
+        "mock_date, expected_week_start, expected_week_end",
+        [
+            ("2024-06-10", "2024-06-10", "2024-06-16"),  # Monday
+            ("2024-06-11", "2024-06-10", "2024-06-16"),  # Tuesday
+            ("2024-06-12", "2024-06-10", "2024-06-16"),  # Wednesday
+            ("2024-06-13", "2024-06-10", "2024-06-16"),  # Thursday
+            ("2024-06-14", "2024-06-10", "2024-06-16"),  # Friday
+            ("2024-06-15", "2024-06-10", "2024-06-16"),  # Saturday
+            ("2024-06-16", "2024-06-10", "2024-06-16"),  # Sunday
+        ],
+    )
+    def test_week_boundaries_all_days(self, monkeypatch, mock_date, expected_week_start, expected_week_end):
+        """Test that same week is returned regardless of which day we start from."""
+        import pendulum
+
+        fixed_today = pendulum.parse(f"{mock_date}T12:00:00")
+        monkeypatch.setattr(pendulum, "today", lambda: fixed_today)
+
+        result = get_relative_date_frame("WEEK", 0)
+        assert result == (expected_week_start, expected_week_end)
+
+    # ==================== DEFAULT PARAMETERS ====================
+    def test_default_parameters(self, mock_today):
+        """Test function with default parameters (MONTH, n=0)."""
+        result = get_relative_date_frame()
+        expected = get_relative_date_frame("MONTH", 0)
+        assert result == expected
+        assert result == ("2024-06-01", "2024-06-30")
+
+    def test_default_month_parameter(self, mock_today):
+        """Test function with only n parameter (default MONTH)."""
+        result = get_relative_date_frame(n=-1)
+        expected = get_relative_date_frame("MONTH", -1)
+        assert result == expected
+        assert result == ("2024-05-01", "2024-05-31")
+
+    # ==================== ERROR HANDLING ====================
+    @pytest.mark.parametrize(
+        "invalid_date_part",
+        [
+            "day",  # lowercase
+            "DAYS",  # plural
+            "months",  # plural + lowercase
+            "invalid",  # completely invalid
+            "SEMESTER",  # not supported
+            "",  # empty string
+            None,  # None value
+        ],
+    )
+    def test_invalid_date_part(self, mock_today, invalid_date_part):
+        """Test that invalid date_part raises ValueError."""
+        with pytest.raises(ValueError, match="date_part must be"):
+            get_relative_date_frame(invalid_date_part, 0)
+
+    # ==================== EDGE CASES ====================
+    def test_zero_offset(self, mock_today):
+        """Test that n=0 returns current period for all date parts."""
+        for date_part in ["DAY", "WEEK", "MONTH", "QUARTER", "YEAR"]:
+            result = get_relative_date_frame(date_part, 0)
+            start_date, end_date = result
+
+            # Verify format
+            assert len(start_date) == 10  # YYYY-MM-DD
+            assert len(end_date) == 10  # YYYY-MM-DD
+            assert start_date <= end_date  # Start should be before or equal to end
+
+    def test_large_offsets(self, mock_today):
+        """Test with large positive and negative offsets."""
+        # Large positive offset
+        result = get_relative_date_frame("YEAR", 100)
+        assert result == ("2124-01-01", "2124-12-31")
+
+        # Large negative offset
+        result = get_relative_date_frame("YEAR", -100)
+        assert result == ("1924-01-01", "1924-12-31")
+
+    # ==================== RETURN TYPE VERIFICATION ====================
+    def test_return_type(self, mock_today):
+        """Test that function returns tuple of two strings."""
+        result = get_relative_date_frame("MONTH", 0)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        assert isinstance(result[0], str)
+        assert isinstance(result[1], str)
+
+        # Verify date format (YYYY-MM-DD)
+        start_date, end_date = result
+        assert len(start_date.split("-")) == 3
+        assert len(end_date.split("-")) == 3


### PR DESCRIPTION
### Relative Date Ranges

```python
from etlutil import get_relative_date_frame

# Current periods (n=0)
current_month = get_relative_date_frame("MONTH", 0)
# Result: ("2024-06-01", "2024-06-30") - current month boundaries

current_quarter = get_relative_date_frame("QUARTER", 0)
# Result: ("2024-04-01", "2024-06-30") - Q2 2024 if current date is in Q2

current_year = get_relative_date_frame("YEAR", 0)
# Result: ("2024-01-01", "2024-12-31") - current year

# Previous periods (n=-1)
last_month = get_relative_date_frame("MONTH", -1)
# Result: ("2024-05-01", "2024-05-31") - previous month
 
# Custom base date (instead of today)
custom_month = get_relative_date_frame("MONTH", 0, date_from="2024-06-15")
# Result: ("2024-06-01", "2024-06-30") - June 2024 regardless of current date

custom_quarter = get_relative_date_frame("QUARTER", -1, date_from=date(2024, 6, 15))
# Result: ("2024-01-01", "2024-03-31") - Q1 2024 (previous quarter from June)

```